### PR TITLE
[Resolutions] Refactoring of UX and naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains
+.idea/

--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Windows.Forms;
 using RatScanner.Properties;
 
 namespace RatScanner
@@ -12,24 +13,32 @@ namespace RatScanner
 	{
 		internal enum Resolution
 		{
-			WXGA,       // 1366x768
-			WXGAPlus,   // 1440x900
-			R1440x1080, // 1440x1080
-			HDPlus,     // 1600x900
-			FHD,        // 1920x1080
-			QHD,        // 2560x1440
-			UHD,        // 3840x2160
+			R1366x768  = 0,
+			R1440x900  = 1,
+			R1440x1080 = 2,
+			R1600x900  = 3,
+			R1920x1080 = 4,
+			R2560x1440 = 5,
+			R3840x2160 = 6,
+			R2560x1080 = 7,
+			R3840x1080 = 8,
+			R3440x1440 = 9,
+			R5120x1440 = 10
 		}
 
 		internal static Dictionary<Resolution, Vector2> ResolutionDict = new Dictionary<Resolution, Vector2>()
 		{
-			{Resolution.WXGA, new Vector2(1366, 768)},
-			{Resolution.WXGAPlus, new Vector2(1440, 900)},
+			{Resolution.R1366x768, new Vector2(1366,  768)},
+			{Resolution.R1440x900, new Vector2(1440,  900)},
 			{Resolution.R1440x1080, new Vector2(1440, 1080)},
-			{Resolution.HDPlus, new Vector2(1600, 900)},
-			{Resolution.FHD, new Vector2(1920, 1080)},
-			{Resolution.QHD, new Vector2(2560, 1440)},
-			{Resolution.UHD, new Vector2(3840, 2160)},
+			{Resolution.R1600x900, new Vector2(1600,  900)},
+			{Resolution.R1920x1080, new Vector2(1920, 1080)},
+			{Resolution.R2560x1440, new Vector2(2560, 1440)},
+			{Resolution.R3840x2160, new Vector2(3840, 2160)},
+			{Resolution.R2560x1080, new Vector2(2560, 1080)},
+			{Resolution.R3840x1080, new Vector2(3840, 1080)},
+			{Resolution.R3440x1440, new Vector2(3440, 1440)},
+			{Resolution.R5120x1440, new Vector2(5210, 1440)},
 		};
 
 		// Version
@@ -108,7 +117,7 @@ namespace RatScanner
 		internal static bool MinimizeToTray = false;
 		internal static bool AlwaysOnTop = true;
 
-		private static Resolution screenResolution = Resolution.FHD;
+		private static Resolution screenResolution = Resolution.R1920x1080;
 		internal static Resolution ScreenResolution
 		{
 			get => screenResolution;
@@ -117,13 +126,17 @@ namespace RatScanner
 				screenResolution = value;
 				switch (screenResolution)
 				{
-					case Resolution.WXGA: LoadWXGA(); break;
-					case Resolution.WXGAPlus: LoadWXGAPlus(); break;
+					case Resolution.R1366x768:  LoadWXGA(); break;
+					case Resolution.R1440x900:  LoadWXGAPlus(); break;
 					case Resolution.R1440x1080: LoadR1440x1080(); break;
-					case Resolution.HDPlus: LoadHDPlus(); break;
-					case Resolution.FHD: LoadFHD(); break;
-					case Resolution.QHD: LoadQHD(); break;
-					case Resolution.UHD: LoadUHD(); break;
+					case Resolution.R1600x900:  LoadHDPlus(); break;
+					case Resolution.R1920x1080: LoadFHD(); break;
+					case Resolution.R2560x1080: LoadFHD(); break;
+					case Resolution.R3840x1080: LoadFHD(); break;
+					case Resolution.R2560x1440: LoadQHD(); break;
+					case Resolution.R3440x1440: LoadQHD(); break;
+					case Resolution.R5120x1440: LoadQHD(); break;
+					case Resolution.R3840x2160: LoadUHD(); break;
 					default: throw new ArgumentOutOfRangeException(nameof(value), "Unknown screen resolution");
 				}
 
@@ -206,14 +219,14 @@ namespace RatScanner
 		{
 			return ScreenResolution switch
 			{
-				Resolution.WXGA => 768f / 1080f,
-				Resolution.WXGAPlus => 900f / 1080f,
-				Resolution.R1440x1080 => 1440f / 1920f,
-				Resolution.HDPlus => 900f / 1080f,
-				Resolution.FHD => 1080f / 1080f,
-				Resolution.QHD => 1440f / 1080f,
-				Resolution.UHD => 2160f / 1080f,
-				_ => throw new InvalidOperationException("Unknown ScreenResolution"),
+		       Resolution.R1366x768  => 768f  / 1080f,
+		       Resolution.R1440x900  => 900f  / 1080f,
+		       Resolution.R1440x1080 => 1440f / 1920f,
+		       Resolution.R1600x900  => 900f  / 1080f,
+		       Resolution.R1920x1080 => 1080f / 1080f,
+		       Resolution.R2560x1440 => 1440f / 1080f,
+		       Resolution.R3840x2160 => 2160f / 1080f,
+		       _                     => throw new InvalidOperationException("Unknown ScreenResolution"),
 			};
 		}
 
@@ -224,7 +237,11 @@ namespace RatScanner
 
 		internal static void LoadConfig()
 		{
-			if (!File.Exists(Paths.ConfigFile)) SaveConfig();
+			if (!File.Exists(Paths.ConfigFile))
+			{
+				TrySetScreenResolution();
+				SaveConfig();
+			}
 
 			var config = new SimpleConfig(Paths.ConfigFile);
 			NameScan.Enable = config.ReadBool(nameof(NameScan.Enable), true);
@@ -247,7 +264,7 @@ namespace RatScanner
 			MinimalUi.ShowUpdated = config.ReadBool(nameof(MinimalUi.ShowUpdated), true);
 			MinimalUi.Opacity = config.ReadInt(nameof(MinimalUi.Opacity), 50);
 
-			ScreenResolution = (Resolution)config.ReadInt(nameof(ScreenResolution), (int)Resolution.FHD);
+			ScreenResolution = (Resolution)config.ReadInt(nameof(ScreenResolution), (int)Resolution.R1920x1080);
 			MinimizeToTray = config.ReadBool(nameof(MinimizeToTray), false);
 			AlwaysOnTop = config.ReadBool(nameof(AlwaysOnTop), false);
 			LogDebug = config.ReadBool(nameof(LogDebug), false);
@@ -280,6 +297,20 @@ namespace RatScanner
 			config.WriteBool(nameof(MinimizeToTray), MinimizeToTray);
 			config.WriteBool(nameof(AlwaysOnTop), AlwaysOnTop);
 			config.WriteBool(nameof(LogDebug), LogDebug);
+		}
+
+		/// <summary>
+		/// Converts PrimaryScreen resolution to Resolution enum, sets screenResolution if a match is found
+		/// </summary>
+		internal static void TrySetScreenResolution()
+		{
+			var boundsRectangle = Screen.PrimaryScreen.Bounds;
+			var resolutionString = $"R{boundsRectangle.Width}x{boundsRectangle.Height}";
+			Enum.TryParse(typeof(Resolution), resolutionString, out var matchingResolution);
+			if (matchingResolution != null)
+			{
+				screenResolution = (Resolution) matchingResolution;
+			}
 		}
 	}
 }

--- a/RatScanner/Scan/ItemIconScan.cs
+++ b/RatScanner/Scan/ItemIconScan.cs
@@ -70,7 +70,7 @@ namespace RatScanner.Scan
 			Logger.LogDebugMat(croppedIcon, "cropped_icon");
 
 			// Rescale captured icon if resolution is not FHD
-			if (RatConfig.ScreenResolution != RatConfig.Resolution.FHD)
+			if (RatConfig.ScreenResolution != RatConfig.Resolution.R1920x1080)
 			{
 				var invSSF = RatConfig.GetInverseScreenScaleFactor();
 				var croppedSize = new Size(croppedIcon.Width * invSSF, croppedIcon.Height * invSSF);

--- a/RatScanner/View/Settings.xaml
+++ b/RatScanner/View/Settings.xaml
@@ -75,13 +75,18 @@
 							VerticalAlignment="Center"
 							SelectedValue="{Binding ScreenResolution}"
 							SelectedValuePath="Tag">
-							<ComboBoxItem Content="WXGA" Tag="0" />
-							<ComboBoxItem Content="WXGA+" Tag="1" />
-							<ComboBoxItem Content="1440x1080" Tag="2" />
-							<ComboBoxItem Content="HD+" Tag="3" />
-							<ComboBoxItem Content="FHD" Tag="4" />
-							<ComboBoxItem Content="QHD" Tag="5" />
-							<ComboBoxItem Content="UHD" Tag="6" />
+							<ComboBoxItem Content="1366 x 768" Tag="0" />
+							<ComboBoxItem Content="1440 x 900" Tag="1" />
+							<ComboBoxItem Content="1440 x 1080" Tag="2" />
+							<ComboBoxItem Content="1600 x 900" Tag="3" />
+							<ComboBoxItem Content="1920 x 1080" Tag="4" />
+							<ComboBoxItem Content="2560 x 1080" Tag="7" />
+							<ComboBoxItem Content="3840 x 1080" Tag="8" />
+							<ComboBoxItem Content="2560 x 1440" Tag="5" />
+							<ComboBoxItem Content="3440 x 1440" Tag="9" />
+							<ComboBoxItem Content="5120 x 1440" Tag="10" />
+							<ComboBoxItem Content="3840 x 2160" Tag="6" />
+
 						</ComboBox>
 
 						<Grid.ColumnDefinitions>


### PR DESCRIPTION
- Explicitly added ultra-wide resolutions (falling back to the already present 1080p or 1440p handling)
- Changed naming convention for resolution names
- Added explicit values for Resolution enum entries
- Added automatic resolution fetching on startup if there is no config file
- Added jetbrains's ide folder to .gitignore


## Note
I did not change the tooltip for the resolution select, you might want to change its contents.